### PR TITLE
fix: clean up stale synced files and update docs for auto-discovery

### DIFF
--- a/.claude/shared-commands/CLAUDE.md
+++ b/.claude/shared-commands/CLAUDE.md
@@ -3,9 +3,17 @@
 Files in this directory are **automatically synced** from the central
 [eSolia/.github](https://github.com/eSolia/.github) repository by `sync.ts`.
 
+Commands are **auto-discovered** — any `.md` file in
+`eSolia/.github/.claude/shared-commands/` (including subdirectories like `dev/`,
+`security/`, `standards/`) is synced automatically. No need to edit `sync.ts`
+when adding or removing commands.
+
 **Do not edit files here directly** — your changes will be overwritten on the
 next sync. If you need to fix a shared command, edit the source in
 `eSolia/.github/.claude/shared-commands/` and re-run sync.
 
-**Repo-specific commands** belong in `.claude/commands/local/` or a similar
-non-synced location.
+Files removed from the central repo are **automatically deleted** from this
+directory on next sync.
+
+**Repo-specific commands** belong in `.claude/commands/local/` (this
+subdirectory is never touched by sync).

--- a/.claude/shared-rules/CLAUDE.md
+++ b/.claude/shared-rules/CLAUDE.md
@@ -3,9 +3,16 @@
 Files in this directory are **automatically synced** from the central
 [eSolia/.github](https://github.com/eSolia/.github) repository by `sync.ts`.
 
+Rules are **auto-discovered** — any `.md` file in
+`eSolia/.github/.claude/shared-rules/` is synced automatically. No need to edit
+`sync.ts` when adding or removing rules.
+
 **Do not edit files here directly** — your changes will be overwritten on the
 next sync. If you need to fix a shared rule, edit the source in
 `eSolia/.github/.claude/shared-rules/` and re-run sync.
 
-**Repo-specific rules** belong in `.claude/rules/local/` or a similar
-non-synced location.
+Files removed from the central repo are **automatically deleted** from this
+directory on next sync.
+
+**Repo-specific rules** belong in `.claude/rules/local/` (this subdirectory is
+never touched by sync).

--- a/README.md
+++ b/README.md
@@ -110,31 +110,11 @@ Every eSolia repository can pull centralized scripts, Claude Code slash commands
 | `submit-bing.mts` | Bing Webmaster URL submission (any site) |
 | `sync-all.sh` | Sync all consumer repos at once (run from esolia.github) |
 
-**Claude Code Commands** (to `.claude/commands/`):
+**Claude Code Commands** (to `.claude/commands/`) — **auto-discovered**. Any `.md` file in `.claude/shared-commands/` (including subdirectories) is synced automatically. No need to edit `sync.ts`.
 
-| Command | Description |
-|---------|-------------|
-| `/backpressure-review` | Deep SvelteKit quality review |
-| `/seo-setup` | SEO checklist and setup |
-| `/checkpoint` | Save session checkpoint to `docs/checkpoints/` |
-| `/commit-style` | Conventional commit and InfoSec reference |
-| `/dev:d1-health` | Cloudflare D1 database health audit |
-| `/dev:preflight` | Show preflight checks for current project |
-| `/dev:svelte-review` | Review code against Svelte 5 best practices |
-| `/security:audit-github-actions` | GitHub Actions security audit |
-| `/security:harden-github-org` | GitHub org and repo hardening |
-| `/standards:check` | Review code against eSolia coding standards |
-| `/standards:list` | List all eSolia standards |
-| `/standards:search` | Search standards by keyword |
-| `/standards:writing` | Review content against eSolia writing guides |
+**Claude Code Rules** (to `.claude/rules/`) — **auto-discovered**. Any `.md` file in `.claude/shared-rules/` is synced automatically. No need to edit `sync.ts`.
 
-**Claude Code Rules** (to `.claude/rules/`):
-
-| Rule | Triggers On |
-|------|-------------|
-| `backpressure-verify` | SvelteKit code changes — auto-runs verify |
-| `d1-maintenance` | D1/wrangler/schema files — enforces indexing and query practices |
-| `mermaid-diagrams` | Markdown/mermaid files — enforces compact styling |
+Files removed from the central repo are automatically deleted from consumer repos on next sync. Repo-specific commands and rules in `local/` subdirectories are never touched.
 
 ### Sync Distribution Architecture
 
@@ -145,9 +125,9 @@ flowchart TD
 
   subgraph assets["What Gets Distributed"]
     direction LR
-    Scripts["Scripts<br/><i>5 shell + 1 TS</i>"]
-    Commands["Commands<br/><i>13 slash commands</i>"]
-    Rules["Rules<br/><i>3 auto-trigger rules</i>"]
+    Scripts["Scripts<br/><i>shell + TS</i>"]
+    Commands["Commands<br/><i>auto-discovered</i>"]
+    Rules["Rules<br/><i>auto-discovered</i>"]
   end
 
   subgraph repos["Consumer Repos (9)"]
@@ -198,10 +178,11 @@ npx tsx scripts/shared/sync.ts          # cross-platform
 
 1. Downloads scripts from this repo into `scripts/shared/` (gitignored)
 2. Creates thin wrapper scripts in `scripts/` that delegate to `scripts/shared/`
-3. Downloads Claude commands into `.claude/commands/`
-4. Downloads Claude rules into `.claude/rules/`
-5. Writes a `.scriptversion` file for staleness checking
-6. Adds `scripts/shared/` to `.gitignore` if not already there
+3. Auto-discovers and downloads Claude commands into `.claude/commands/`
+4. Auto-discovers and downloads Claude rules into `.claude/rules/`
+5. Removes stale commands/rules that no longer exist in the central repo
+6. Writes a `.scriptversion` file for staleness checking
+7. Adds `scripts/shared/` to `.gitignore` if not already there
 
 The wrapper pattern means your repo only commits the 4-line wrapper, not the full script. Updates flow through `sync.sh`/`sync.ts`.
 

--- a/scripts/sync.ts
+++ b/scripts/sync.ts
@@ -17,8 +17,10 @@ import {
   chmodSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -292,6 +294,43 @@ exec "$SCRIPT_DIR/shared/${name}" "$@"
   success(`Created wrapper: scripts/${name}`);
 }
 
+/**
+ * Remove local files that were previously synced but no longer exist in the
+ * remote source. Compares the files on disk against the list of files just
+ * discovered from the remote, and deletes any extras.
+ *
+ * Skips:
+ *  - CLAUDE.md (the directory's own readme, always synced separately)
+ *  - Files inside a "local/" subdirectory (repo-specific, never synced)
+ */
+function cleanupStaleFiles(
+  targetDir: string,
+  syncedEntries: SyncEntry[],
+  label: string,
+): void {
+  if (!existsSync(targetDir)) return;
+
+  const remoteDests = new Set(syncedEntries.map((e) => e.dest));
+
+  function walkDir(dir: string, prefix: string): void {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+
+      // Never touch local/ subdirectories
+      if (entry.isDirectory() && entry.name === "local") continue;
+
+      if (entry.isDirectory()) {
+        walkDir(join(dir, entry.name), relPath);
+      } else if (!remoteDests.has(relPath)) {
+        unlinkSync(join(dir, entry.name));
+        warning(`Removed stale ${label}: ${relPath}`);
+      }
+    }
+  }
+
+  walkDir(targetDir, "");
+}
+
 function addToGitignore(): void {
   const gitignorePath = join(PROJECT_ROOT, ".gitignore");
   if (existsSync(gitignorePath)) {
@@ -418,6 +457,12 @@ async function main() {
       await downloadFiles(SYNC_WORKFLOWS, workflowsDir);
       console.log();
     }
+
+    // Remove files that no longer exist in the remote
+    step("Cleaning up stale synced files...");
+    cleanupStaleFiles(commandsDir, syncedCommands, "command");
+    cleanupStaleFiles(rulesDir, syncedRules, "rule");
+    console.log();
   }
 
   // 3. Write .scriptversion


### PR DESCRIPTION
## Summary

- `sync.ts` now **deletes stale files** from `.claude/commands/` and `.claude/rules/` in consumer repos when the source file is removed from the central repo. Files in `local/` subdirectories are never touched.
- Updated `README.md` — replaced hardcoded command/rule tables with auto-discovery explanation
- Updated `shared-commands/CLAUDE.md` and `shared-rules/CLAUDE.md` — documents auto-discovery and automatic cleanup

Closes #3

## Test plan

- [ ] Add a dummy rule to `.claude/shared-rules/`, sync a consumer repo, verify it appears
- [ ] Remove the dummy rule, sync again, verify it is deleted from the consumer repo
- [ ] Create a `local/my-rule.md` in a consumer repo's `.claude/rules/`, sync, verify it survives
- [ ] Run `sync.ts --scripts-only` and verify no command/rule cleanup runs
- [ ] Verify README.md renders correctly on GitHub