### PR TITLE
docs: add FAST_TRACK=1 bypass syntax to change-management rule

### DIFF
--- a/.claude/shared-rules/change-management.md
+++ b/.claude/shared-rules/change-management.md
@@ -29,6 +29,7 @@ Fast-track changes still require:
 - A descriptive conventional commit message
 - The InfoSec/quality annotation line
 - Post-push CI verification
+- The `FAST_TRACK=1` env var to bypass the pre-commit hook: `FAST_TRACK=1 git commit -m "fix: ..."`
 
 ## Conventional Commits
 


### PR DESCRIPTION
## Summary

- Add `FAST_TRACK=1 git commit` syntax to the fast-track section of `change-management.md` so Claude Code (and humans) know how to bypass the pre-commit hook for trivial changes

Closes #5

## Test plan

- [ ] Verify the rule file reads clearly with the new line
- [ ] Confirm the symlink at `~/.claude/rules/change-management.md` reflects the update after merge + sync