### PR TITLE
chore: add quality tooling (editorconfig, prettier, markdownlint)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,19 @@
+# Markdownlint config
+# CJK-aware punctuation support for bilingual content
+
+default: true
+
+MD013:
+  line_length: 200
+  heading_line_length: 120
+  code_block_line_length: 200
+
+MD033: false
+MD034: false
+MD036: false
+
+MD024:
+  siblings_only: true
+
+MD026:
+  punctuation: ".,;:!。，；：！"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+_site/
+.wrangler/
+*.min.js
+deno.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100,
+  "semi": true,
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
## Summary

- Add `.editorconfig`, `.prettierrc`, `.prettierignore`, `.markdownlint.yml` matching conventions from consumer repos (pulse, etc.)
- These were present in app repos but missing from the .github profile repo

Closes #10

## Test plan

- [ ] Verify configs are at repo root
- [ ] Verify `.prettierrc` matches pulse conventions (single quotes, 100 width)
- [ ] Verify `.markdownlint.yml` has CJK-aware punctuation