### PR TITLE
fix(scripts): resolve slug collision in cross-post manifest

### DIFF
--- a/scripts/cross-post-devto.mts
+++ b/scripts/cross-post-devto.mts
@@ -480,9 +480,22 @@ function loadFromFile(filePath: string): ArticleInput {
 
   const raw = readFileSync(absPath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
-  const slug = basename(absPath, ".md");
+  const slug = deriveSlug(absPath);
 
   return { slug, frontmatter, body };
+}
+
+// Derive a manifest key from the file path. When the markdown file follows the
+// convention {article-slug}/devto.md, basename() alone gives "devto", which
+// collides across articles and causes silent overwrites in --update mode.
+// Fall back to the parent directory name for generic filenames; otherwise use
+// the filename as before (backwards-compatible for standalone .md files).
+function deriveSlug(absPath: string): string {
+  const base = basename(absPath, ".md");
+  if (base === "devto" || base === "qiita") {
+    return basename(dirname(absPath));
+  }
+  return base;
 }
 
 function loadFromDir(dirPath: string): ArticleInput[] {

--- a/scripts/cross-post-qiita.mts
+++ b/scripts/cross-post-qiita.mts
@@ -295,9 +295,22 @@ function loadFromFile(filePath: string): ArticleInput {
 
   const raw = readFileSync(absPath, "utf-8");
   const { frontmatter, body } = parseFrontmatter(raw);
-  const slug = basename(absPath, ".md");
+  const slug = deriveSlug(absPath);
 
   return { slug, frontmatter, body };
+}
+
+// Derive a manifest key from the file path. When the markdown file follows the
+// convention {article-slug}/qiita.md, basename() alone gives "qiita", which
+// collides across articles and causes silent overwrites in --update mode.
+// Fall back to the parent directory name for generic filenames; otherwise use
+// the filename as before (backwards-compatible for standalone .md files).
+function deriveSlug(absPath: string): string {
+  const base = basename(absPath, ".md");
+  if (base === "devto" || base === "qiita") {
+    return basename(dirname(absPath));
+  }
+  return base;
 }
 
 function loadFromDir(dirPath: string): ArticleInput[] {


### PR DESCRIPTION
## Summary

- Cross-post scripts were deriving the manifest key from \`basename(file, \".md\")\`, which collides when files follow the common \`{article-slug}/devto.md\` / \`{article-slug}/qiita.md\` convention — every article produced the same key (\`\"devto\"\` / \`\"qiita\"\`), causing subsequent crosspost runs in \`--update\` mode to silently overwrite prior articles on Dev.to / Qiita.
- Extracted \`deriveSlug()\` helper that falls back to the parent directory name when the filename is one of the generic names \`devto\` / \`qiita\`. Standalone \`.md\` files keep the previous filename-based behaviour.
- Applied identically to \`cross-post-devto.mts\` and \`cross-post-qiita.mts\`.

Closes #12

## Test plan

- [x] Manually traced logic for three cases:
  - \`my-article/devto.md\` → slug \`\"my-article\"\` ✓
  - \`my-article/qiita.md\` → slug \`\"my-article\"\` ✓
  - \`standalone-article.md\` → slug \`\"standalone-article\"\` (backwards-compat)
- [ ] Downstream verify: after sync to \`RickCogley/pub-cogley\`, re-run a crosspost for an existing tracked article in \`--dry-run\` mode; the console output should show the article's real slug (e.g. \`slug: japan-ipa-security-action-sme\`) rather than the generic \`slug: devto\` it showed before.

## Notes

Bug surfaced in \`RickCogley/pub-cogley\` while cross-posting the \`japan-ipa-security-action-sme\` article — overwrote the prior \`engineering-backpressure-ai-code-quality\` Dev.to article and caused a duplicate Qiita draft. Manual recovery done; this PR prevents recurrence.