### PR TITLE
chore(ci): bump Node 20 actions to Node 24-based versions

### DIFF
--- a/.github/workflows/update-profile-readme.yml
+++ b/.github/workflows/update-profile-readme.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: true  # Required for git-auto-commit to push
 
       - name: Setup Deno environment
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
         with:
           deno-version: v2.x
 
@@ -37,7 +37,7 @@ jobs:
         run: deno task build
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0
         with:
           commit_message: Apply changes during gh actions build
           status_options: '--untracked-files=no'

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 [![Proven.lol Lightweight Proof](https://img.shields.io/badge/Proven.lol-Lightweight_Proof-green?style=flat-square&logo=cachet)](https://proven.lol/fbd788)
 
-**Last Updated:** April 24th, 2026 at 5:02:56 AM GMT+9 &nbsp; **Today is:** Friday, April 24, 2026
+**Last Updated:** April 24th, 2026 at 6:59:19 AM GMT+9 &nbsp; **Today is:** Friday, April 24, 2026
 
 ## Welcome 👋
 


### PR DESCRIPTION
## Summary

- Bump `denoland/setup-deno` v2.0.3 → v2.0.4
- Bump `stefanzweifel/git-auto-commit-action` v5 → v7.1.0
- Both target versions declare `using: node24`, clearing GitHub's Node 20 deprecation warning (forced switch 2026-06-02, removal 2026-09-16)
- Closes #20

## Compatibility note (git-auto-commit-action v5 → v7)

v6 dropped `skip_fetch` / `skip_checkout` / `create_branch`; v7 restored them. This workflow uses only `commit_message` and `status_options`, so no input-schema changes are needed.

## Test plan

- [x] SHAs resolved via GitHub API (pinned + comment preserved per CI/CD hardening policy)
- [ ] `Update Profile README` workflow runs green on this PR
- [ ] Post-merge run succeeds with no Node 20 annotation
- [ ] CodeQL passes

InfoSec: dependency upgrade to restore supported runtime before EOL. No new permissions, secrets, or inputs introduced.